### PR TITLE
Update PHP version to 8.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -66,7 +66,7 @@ ram.runtime = "50M"
     api.show_tile = false
 
     [resources.apt]
-    packages = "mariadb-server, php8.2-mysql, php8.2-mbstring, php8.2-xml, php8.2-curl, php8.2-gd, php8.2-imagick, php8.2-ldap"
+    packages = "mariadb-server, php8.3-mysql, php8.3-mbstring, php8.3-xml, php8.3-curl, php8.3-gd, php8.3-imagick, php8.3-ldap"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
PHP 8.3 is more recent than PHP 8.2 and as per https://github.com/Leantime/leantime?tab=readme-ov-file#system-requirements it is supported.